### PR TITLE
CAN Publisher/Subscriber

### DIFF
--- a/can_controller/CMakeLists.txt
+++ b/can_controller/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.5)
+project(can_controller)
+
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(ctre REQUIRED)
+
+add_executable(velocity_to_can src/velocity_to_can.cpp)
+target_include_directories(velocity_to_can PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+
+install(TARGETS velocity_to_can
+  DESTINATION lib/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # uncomment the line when a copyright and license is not present in all source files
+  #set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # uncomment the line when this package is not in a git repo
+  #set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/can_controller/package.xml
+++ b/can_controller/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>can_controller</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer></maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>ctre</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/can_controller/src/velocity_to_can.cpp
+++ b/can_controller/src/velocity_to_can.cpp
@@ -1,0 +1,95 @@
+#include <cstdio>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+#include <tuple>
+
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
+#include "geometry_msgs/Twist.h"
+
+// TODO: Install the following libraries:
+#include "ctre/Phoenix.h"
+#include "ctre/phoenix/platform/Platform.h"
+#include "ctre/phoenix/unmanaged/Unmanaged.h"
+#include "ctre/phoenix/cci/Unmanaged_CCI.h"
+
+using namespace std::chrono_literals;
+using namespace ctre::phoenix;
+using namespace ctre::phoenix::platform;
+using namespace ctre::phoenix::motorcontrol;
+using namespace ctre::phoenix::motorcontrol::can;
+
+// TODO: Update these port numbers!
+TalonSRX talLeft(1);
+TalonSRX talRght(0);
+
+talLeft.ConfigSelectedFeedbackSensor(...); // TODO: finish filling out, though it may be unnecessary.
+
+int kPIDLoopIdx = 0;
+int kTimeoutMs = 30;
+
+talLeft.Config_kF(kPIDLoopIdx, 0, kTimeoutMs); // TODO: Tune PIDF values according to https://phoenix-documentation.readthedocs.io/en/latest/ch16_ClosedLoop.html.
+talLeft.Config_kP(kPIDLoopIdx, 0, kTimeoutMs); // CHECK WHILE TESTING: this might have to be moved to main, alongside the ConfigSelectedFeedbackSensor()
+talLeft.Config_kI(kPIDLoopIdx, 0, kTimeoutMs);
+talLeft.Config_kD(kPIDLoopIdx, 0, kTimeoutMs);
+
+void initDrive()
+{
+	talRght.SetInverted(false); /* both talons should blink green when driving forward */
+}
+
+void drive(double left, double right)
+{
+	talLeft.Set(ControlMode::Velocity, left);
+	talRght.Set(ControlMode::Velocity, right);
+}
+
+class TalonNode : public rclcpp::Node
+{
+  public:
+    TalonNode()
+    : Node("talon_interface")
+    {
+      motion_subscriber_ = this->create_subscription<tuple>("PLACEHOLDER_VELOCITY_TOPIC", 10, std::bind(&PathfinderSubscriber::topic_callback, this, _1));
+      left_encoder_publisher_ = this->create_publisher<geometry_msgs::Twist>("cmd_vel/left_wheel_encoder_position", 10)
+      right_encoder_publisher_ = this->create_publisher<geometry_msgs::Twist>("cmd_vel/right_wheel_encoder_position", 10)
+      timer_ = this->create_wall_timer(20ms, std::bind(&TalonNode::timer_callback, this)); //TODO: Change timer time.
+    }
+  //TODO: WARNING—CURRENTLY, THIS AUTOMATICALLY RUNS THE MOTORS WHENEVER THIS NODE IS RUNNING... JUST FYI.
+  private:
+    void topic_callback(const tuple::SharedPtr msg) const
+    {
+      double left_vel = get<0>msg;
+      double right_vel = get<1>msg;
+      drive(left_vel, right_vel);
+    }
+    
+    void timer_callback()
+    {
+      geometry_msgs::Twist left_encoder_out;
+      geometry_msgs::Twist right_encoder_out;
+      left_encoder_out.linear.x = talLeft.getSelectedSensorVelocity();
+      right_encoder_out.linear.x = talRight.getSelectedSensorVelocity();
+      left_encoder_publisher_->publish(left_encoder_out);
+      right_encoder_publisher_->publish(right_encoder_out);
+    }
+    rclcpp::Subscription<tuple>::SharedPtr motion_subscriber_;
+    rclcpp::TimerBase::SharedPtr timer_;
+    rclcpp::Publisher<geometry_msgs::Twist>::SharedPtr left_encoder_publisher_;
+    rclcpp::Publisher<geometry_msgs::Twist>::SharedPtr right_encoder_publisher_;
+    size_t count_;
+
+};
+
+int main(int argc, char ** argv)
+{
+  std::string interface = "can0";
+  ctre::phoenix::platform::can::SetCANInterface(interface.c_str()); 
+  initDrive();
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<MinimalSubscriber>());
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
https://github.com/metrobot-research/metrobot_ros/pull/1, but moved to this folder system. Still needs to be tested.

`Adds a publisher/subscriber node that reads from some yet-to-be-determined pathfinder node, sets the talon's accordingly, while reading from the VP encoders, and publishing their speeds to separate encoder topics.`